### PR TITLE
Use 'rm -rf' remove bin and obj instead of bin/* and obj/*

### DIFF
--- a/makefile
+++ b/makefile
@@ -67,8 +67,7 @@ $(CHECK_DIR):
 	mkdir -p $@
 
 clean:
-	rm bin/*
-	rm obj/*
+	rm -rf bin obj
 
 html:
 	cd $(CURREND) && htags -g -F && htags -Ffnsa


### PR DESCRIPTION
Without '-f', 'make clean all' breaks if there's nothing in bin/ or
obj/. Since d40619bd makefile checks dirs and create them when
'make all', it's safe now to remove the directories directly, and
create new ones later.

Signed-off-by: Phidias Chiang <phidias.chiang@gmail.com>