### PR TITLE
Use https url instead of ssh connection for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mpc"]
 	path = mpc
-	url = git@github.com:orangeduck/mpc.git
+	url = https://github.com/orangeduck/mpc.git


### PR DESCRIPTION
When the developer's environment doesn't use SSH key to access github,
the clone for submodule will failed. Change the url to explictly use
https solve this problem.

Signed-off-by: Phidias Chiang <phidias.chiang@gmail.com>